### PR TITLE
Supplemental documents

### DIFF
--- a/app/assets/javascripts/proposal.js.coffee
+++ b/app/assets/javascripts/proposal.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/proposal.css.scss
+++ b/app/assets/stylesheets/proposal.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Proposal controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/grant_submissions_controller.rb
+++ b/app/controllers/grant_submissions_controller.rb
@@ -182,6 +182,9 @@ class GrantSubmissionsController < ApplicationController
     if !artist_logged_in? && !admin_logged_in?
       @answer_edit_disable = true
     end
+
+    @supplements = Proposal.where(grant_submission_id: @grant_submission.id)
+    @proposal = Proposal.new
   end
 
   def grant_contract_params

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,0 +1,47 @@
+class ProposalsController < ApplicationController
+
+  before_filter :verify_correct_artist
+
+  def verify_correct_artist
+    if admin_logged_in?
+      return
+    end
+
+    if !current_artist
+      redirect_to "/"
+      return
+    end
+    begin
+      @grant_submission = GrantSubmission.find(params.permit(:grant_submission_id, :authenticity_token)[:grant_submission_id])
+    rescue
+      redirect_to "/"
+      return
+    end
+    if @grant_submission.artist_id != current_artist.id
+      logger.warning "Attempt to upload supplement for submission not owned by current artist"
+      redirect_to "/"
+      return
+    end
+  end
+
+  def proposal_params
+    params.require(:proposal).permit(:grant_submission_id, :file, :id)
+  end
+
+  def create
+    @proposal = Proposal.new(proposal_params)
+    if @proposal.save
+      redirect_to :controller => "grant_submissions", :action => "discuss",
+          :id => proposal_params[:grant_submission_id]
+    else
+      render "upload_failure"
+    end
+  end
+
+  def delete
+    @proposal = Proposal.find(proposal_params[:id])
+    @proposal.destroy
+    redirect_to :controller => "grant_submissions", :action => "discuss",
+          :id => proposal_params[:grant_submission_id]
+  end
+end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -40,8 +40,12 @@ class ProposalsController < ApplicationController
 
   def delete
     @proposal = Proposal.find(proposal_params[:id])
-    @proposal.destroy
-    redirect_to :controller => "grant_submissions", :action => "discuss",
-          :id => proposal_params[:grant_submission_id]
+    begin
+      @proposal.destroy
+      redirect_to :controller => "grant_submissions", :action => "discuss",
+            :id => proposal_params[:grant_submission_id]
+    rescue
+      render "destroy_failure"
+    end
   end
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -1,0 +1,2 @@
+module ProposalsHelper
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,0 +1,19 @@
+class Proposal < ActiveRecord::Base
+  mount_uploader :file, GrantProposalUploader
+
+  validates :file, :presence => true
+
+  validates :grant_submission_id, :presence => true
+
+  # This is supposed to check size before upload but I don't think it does.
+  # It does validate after upload, though, so it's not DDOS-proof but it will
+  # prevent randos from using the grants server as an ftp site
+  validate :file_validation, :if => "file?"
+
+  def file_validation
+    if file.size > 100.megabytes
+      logger.warn "rejecting large upload: #{file.inspect}"
+      errors[:file] << "File must be less than 100MB"
+    end
+  end
+end

--- a/app/views/grant_submissions/discuss.html.erb
+++ b/app/views/grant_submissions/discuss.html.erb
@@ -15,8 +15,31 @@
           <%= submit_tag("Update Discussion", class: "button")%>
         <% end %>
       </fieldset>
-    <br />
     <% end %>
+    <% if !@supplements.empty? %>
+      <h2>Supplemental documents</h2>
+      <table style="border:none;">
+      <% @supplements.each do |s| %>
+        <tr><td style="border:none;">
+          <%= form_tag("/proposals/delete", authenticity_token: true, :class => "button_to") do %>
+            <%= hidden_field_tag :grant_submission_id, @grant_submission.id, :name => "proposal[grant_submission_id]" %>
+            <%= hidden_field_tag :id, s.id, :name => "proposal[id]" %>
+            <input class="button" name="delete" type="submit" value="Delete" />
+          <% end %>
+        </td>
+        <td style="border:none;"><a href="<%= s.file %>"><%= s.file_identifier %></a></td>
+        </tr>
+      <% end %>
+      </table>
+    <% end %>
+    <br/>
+    <%= semantic_form_for @proposal, :html => { :onsubmit => 'return validate();'} do |f| %>
+      <label class="label" for="proposal_file">Upload Additional Document:</label>
+      <%= f.file_field :file, :required => true, :validate => true, :accept => ".pdf,.doc,.docx,.txt,.md" %>
+      <%= hidden_field_tag :grant_submission_id, @grant_submission.id, :name => "proposal[grant_submission_id]" %>
+      <%= submit_tag("Upload", class: "button") %>
+    <% end %>
+    <br />
     <% if artist_logged_in? %>
       <%= link_to 'Back', :controller => "artists", :action => "index" %>
     <% elsif admin_logged_in? %>
@@ -31,3 +54,16 @@
     <%= link_to 'Back', :back %>
   <% end %>
 </div>
+
+<script>
+function validate() {
+  if(document.getElementById("proposal_file").value != "") {
+    document.getElementById("proposal_file").style.border = '1px solid green';
+    return true;
+  } else {
+    alert('error: please select your application PDF')
+    document.getElementById("proposal_file").style.border = '1px solid red';
+    return false;
+  }
+}
+</script>

--- a/app/views/proposals/delete_failure.html.erb
+++ b/app/views/proposals/delete_failure.html.erb
@@ -1,0 +1,26 @@
+<div class="container">
+    <h1><%= link_to "Firefly Art Grants", :controller => "home", :action => "index" %>: Failure!</h1>
+
+    Error deleting supplemental document.
+
+    <% if @proposal.errors.messages.any? %>
+      <br/>
+      Errors:
+      <ul>
+      <% @proposal.errors.messages.each do |field, errors| %>
+        <% errors.each do |m| %>
+          <li><%= m %></li>
+        <% end %>
+      <% end %>
+      </ul>
+    <% end %>
+
+    <br /><br />
+
+    Please try again or contact <a href="mailto:grants@fireflyartscollective.org">grants@fireflyartscollective.org</a> for help.
+
+    <br /><br />
+
+    <%= link_to "Back", :controller => "artists", :action => "index" %>
+</div>
+

--- a/app/views/proposals/upload_failure.html.erb
+++ b/app/views/proposals/upload_failure.html.erb
@@ -1,0 +1,26 @@
+<div class="container">
+    <h1><%= link_to "Firefly Art Grants", :controller => "home", :action => "index" %>: Failure!</h1>
+
+    Your supplement upload failed. Sorry :(
+
+    <% if @proposal.errors.messages.any? %>
+      <br/>
+      Errors:
+      <ul>
+      <% @proposal.errors.messages.each do |field, errors| %>
+        <% errors.each do |m| %>
+          <li><%= m %></li>
+        <% end %>
+      <% end %>
+      </ul>
+    <% end %>
+
+    <br /><br />
+
+    Please try again or contact <a href="mailto:grants@fireflyartscollective.org">grants@fireflyartscollective.org</a> for help.
+
+    <br /><br />
+
+    <%= link_to "Back", :controller => "artists", :action => "index" %>
+</div>
+

--- a/app/views/user_mailer/notify_questions.html.erb
+++ b/app/views/user_mailer/notify_questions.html.erb
@@ -5,7 +5,9 @@
 
 <p>After reviewing your submission, the committee had a few questions. Please
 log in to the <%= link_to "Art Grant portal", artists_url() %> and click on
-"Questions From Committee" and enter your responses in the box provided.</p>
+"Questions From Committee" and enter your responses in the box provided. If you
+have additional documents to provide, scroll to the bottom of the dicussion
+page and click "Upload Additional Document."</p>
 
 <p>Please answer these by end-of-day on <%= @due_date %> so that we can consider
 your feedback when making our final funding decisions. You may reply to this

--- a/app/views/user_mailer/notify_questions.text.erb
+++ b/app/views/user_mailer/notify_questions.text.erb
@@ -1,13 +1,20 @@
 <%= @artist.name %>,
 
-Thank you for taking the time and effort to pull together a proposal for the <%= @year %> Firefly <%= @grant.name %> Grant!
+Thank you for taking the time and effort to pull together a proposal for the <%= @year %>
+Firefly <%= @grant.name %> Grant!
 
-After reviewing your submission, the committee had a few questions. Please log in to the Art Grant portal and click on "Questions From Committee" and enter your responses in the box provided.
+After reviewing your submission, the committee had a few questions. Please log
+in to the Art Grant portal and click on "Questions From Committee" and enter
+your responses in the box provided. If you have additional documents to provide,
+scroll to the bottom of the dicussion page and click "Upload Additional Document."
 
 <%= artists_url() %>
 
-Please answer these by end-of-day on <%= @due_date %> so that we can consider your feedback when making our final funding decisions. You may reply to this email and attach any additional files you'd like to include.
+Please answer these by end-of-day on <%= @due_date %> so that we can consider your
+feedback when making our final funding decisions. You may reply to this email
+and attach any additional files you'd like to include.
 
-Thanks again for submitting and for your time! We look forward to hearing back from you.
+Thanks again for submitting and for your time! We look forward to hearing back
+from you.
 
 - Firefly Art Grants Core

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   post 'artists/modify_grant' => 'grant_submissions#modify'
   post 'grant_submissions/delete' => 'grant_submissions#delete'
   post 'grant_submissions/generate_contract' => 'grant_submissions#generate_contract'
+  post 'proposals/delete' => 'proposals#delete'
 
   post 'voters/vote' => 'voters#vote'
 
@@ -59,6 +60,7 @@ Rails.application.routes.draw do
   resources :artists, :voters, :admins, :grant_submissions, :grants
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
+  resources :proposals
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/db/migrate/20161123174455_create_proposals.rb
+++ b/db/migrate/20161123174455_create_proposals.rb
@@ -1,0 +1,8 @@
+class CreateProposals < ActiveRecord::Migration
+  def change
+    create_table :proposals do |t|
+      t.string :file
+    end
+    add_reference :proposals, :grant_submission, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123022557) do
+ActiveRecord::Schema.define(version: 20161123174455) do
 
   create_table "admins", force: true do |t|
     t.string   "name"
@@ -91,6 +91,13 @@ ActiveRecord::Schema.define(version: 20161123022557) do
     t.datetime "vote_start"
     t.datetime "vote_end"
   end
+
+  create_table "proposals", force: true do |t|
+    t.string  "file"
+    t.integer "grant_submission_id"
+  end
+
+  add_index "proposals", ["grant_submission_id"], name: "index_proposals_on_grant_submission_id"
 
   create_table "voter_submission_assignments", force: true do |t|
     t.datetime "created_at"

--- a/test/controllers/proposals_controller_test.rb
+++ b/test/controllers/proposals_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProposalControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/helpers/proposals_helper_test.rb
+++ b/test/helpers/proposals_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class ProposalHelperTest < ActionView::TestCase
+end


### PR DESCRIPTION
Add support for uploading supplemental documents as part of the discussion.
Eventually all proposal files should use this new table and we should
get rid of the special field in grant_submissions

Fixes #33 