### PR TITLE
Ignore /db/*.sqlite3-journal files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ capybara-*.html
 /log
 /tmp
 /db/*.sqlite3
+/db/*.sqlite3-journal
 /public/system
 /public/uploads/tmp/
 /coverage/


### PR DESCRIPTION
A `db/test.sqlite3-journal` file is often present while running tests.