### PR TITLE
Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+Metrics/LineLength:
+  Enabled: false
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test, :development do
 
   gem 'timecop'
 
+  gem 'rubocop', require: false
   gem 'bundler-audit', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       tzinfo (~> 1.1)
     afm (0.2.2)
     arel (6.0.4)
+    ast (2.3.0)
     bcrypt (3.1.11)
     builder (3.2.3)
     bundler-audit (0.5.0)
@@ -145,6 +146,8 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    parser (2.3.3.1)
+      ast (~> 2.2)
     pdf-core (0.6.1)
     pdf-inspector (1.2.1)
       pdf-reader (~> 1.0)
@@ -154,6 +157,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
+    powerpack (0.1.1)
     prawn (2.1.0)
       pdf-core (~> 0.6.1)
       ttfunk (~> 1.4.0)
@@ -188,6 +192,7 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
@@ -221,6 +226,13 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (0.46.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
     sass (3.2.19)
@@ -263,6 +275,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.2)
     unicode_utils (1.4.0)
 
 PLATFORMS
@@ -293,6 +306,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rspec_junit_formatter
+  rubocop
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   spring

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -5,9 +5,9 @@ class Admin < ActiveRecord::Base
 
   has_secure_password
 
-  validates :name, :presence => true, length: { minimum: 4 }
-  validates :email, :presence => true
-  validates :password, :length => { :minimum => 4 }, :on => :create
+  validates :name, presence: true, length: { minimum: 4 }
+  validates :email, presence: true
+  validates :password, length: { minimum: 4 }, on: :create
 
-  validates_confirmation_of :password, :on => :create
+  validates_confirmation_of :password, on: :create
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -7,11 +7,11 @@ class Artist < ActiveRecord::Base
   has_many :artist_surveys
   has_many :grant_submissions
 
-  validates :name, :presence => true, length: { minimum: 4 }
-  validates :email, :presence => true
-  validates :password, :length => { :minimum => 4 }, :on => :create
+  validates :name, presence: true, length: { minimum: 4 }
+  validates :email, presence: true
+  validates :password, length: { minimum: 4 }, on: :create
 
-  validates_confirmation_of :password, :on => :create
+  validates_confirmation_of :password, on: :create
 
   def country_name
     country = ISO3166::Country[contact_country]

--- a/app/models/artist_survey.rb
+++ b/app/models/artist_survey.rb
@@ -1,5 +1,5 @@
 class ArtistSurvey < ActiveRecord::Base
   belongs_to :artist
 
-  # TODO does this need any validation?
+  # TODO: does this need any validation?
 end

--- a/app/models/concerns/activatable.rb
+++ b/app/models/concerns/activatable.rb
@@ -15,10 +15,10 @@ module Activatable
     def activate!
       return if activated?
 
-      update!({
+      update!(
         activated: true,
-        activated_at: Time.zone.now,
-      })
+        activated_at: Time.zone.now
+      )
     end
 
     def activation_token_valid?(token)

--- a/app/models/concerns/password_reset.rb
+++ b/app/models/concerns/password_reset.rb
@@ -14,7 +14,7 @@ module PasswordReset
     # Sends password reset email.
     def send_password_reset_email
       UserMailer.password_reset(self.class.name.to_s.downcase.pluralize, self).deliver_now
-      logger.info "email: admin password reset sent to #{self.email}"
+      logger.info "email: admin password reset sent to #{email}"
     end
 
     # Returns true if a password reset has expired.

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -3,13 +3,13 @@ class Grant < ActiveRecord::Base
   has_many :grant_submissions
 
   validates :name, presence: true
-  validates :max_funding_dollars, presence: true, numericality: { greater_than: 0, only_integer: true}
-  validates :submit_start,  presence: true
-  validates :submit_end,  presence: true
-  validates :vote_start,  presence: true
-  validates :vote_end,  presence: true
-  validates :meeting_one,  presence: true
-  validates :meeting_two,  presence: true
+  validates :max_funding_dollars, presence: true, numericality: { greater_than: 0, only_integer: true }
+  validates :submit_start, presence: true
+  validates :submit_end, presence: true
+  validates :vote_start, presence: true
+  validates :vote_end, presence: true
+  validates :meeting_one, presence: true
+  validates :meeting_two, presence: true
   # Currently the only place the "hidden" attribute is used is in the voter
   # signup page.  The intent is that some grants may be private and only voted
   # on by the Art Core.  Admins should modify individual voters to add them
@@ -20,20 +20,15 @@ class Grant < ActiveRecord::Base
   private
 
   def dates_ordering
-    if submit_start > submit_end
-      errors.add(:submit_start, "must be after submission end date")
-    end
-    if vote_start > vote_end
-      errors.add(:vote_start, "must be after vote end date")
-    end
-    if meeting_one > vote_end
-      errors.add(:meeting_one, "must be before vote end date")
-    end
-    if meeting_two > vote_end
-      errors.add(:meeting_two, "must be before vote end date")
-    end
-    if meeting_one > meeting_two
-      errors.add(:meeting_one, "must be before second meeting")
-    end
+    validate_date_order(submit_start, submit_end, :submit_start, 'must be after submission end date')
+    validate_date_order(vote_start, vote_end, :vote_start, 'must be after vote end date')
+    validate_date_order(meeting_one, vote_end, :meeting_one, 'must be before vote end date')
+    validate_date_order(meeting_two, vote_end, :meeting_two, 'must be before vote end date')
+    validate_date_order(meeting_one, meeting_two, :meeting_one, 'must be before second meeting')
+  end
+
+  def validate_date_order(first_date, second_date, error_key, error_message)
+    return if second_date > first_date
+    errors.add(error_key, error_message)
   end
 end

--- a/app/models/grant_submission.rb
+++ b/app/models/grant_submission.rb
@@ -25,9 +25,9 @@ class GrantSubmission < ActiveRecord::Base
   validate :proposal_validation, if: :proposal?
 
   def proposal_validation
-    if proposal.size > 100.megabytes
-      logger.warn "rejecting large upload: #{proposal.inspect}"
-      errors[:proposal] << "File must be less than 100MB"
-    end
+    return unless proposal.size > 100.megabytes
+
+    logger.warn "rejecting large upload: #{proposal.inspect}"
+    errors[:proposal] << 'File must be less than 100MB'
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -13,9 +13,9 @@ class Proposal < ActiveRecord::Base
   validate :file_validation, if: :file?
 
   def file_validation
-    if file.size > 100.megabytes
-      logger.warn "rejecting large upload: #{file.inspect}"
-      errors[:file] << "File must be less than 100MB"
-    end
+    return unless file.size > 100.megabytes
+
+    logger.warn "rejecting large upload: #{file.inspect}"
+    errors[:file] << 'File must be less than 100MB'
   end
 end

--- a/app/models/voter.rb
+++ b/app/models/voter.rb
@@ -9,9 +9,9 @@ class Voter < ActiveRecord::Base
   has_many :voter_submission_assignments
   has_many :voter_surveys
 
-  validates :name, :presence => true, length: { minimum: 4 }
-  validates :email, :presence => true
-  validates :password, :length => { :minimum => 4 }, :on => :create
+  validates :name, presence: true, length: { minimum: 4 }
+  validates :email, presence: true
+  validates :password, length: { minimum: 4 }, on: :create
 
-  validates_confirmation_of :password, :on => :create
+  validates_confirmation_of :password, on: :create
 end

--- a/lib/tasks/grant_contracts.rake
+++ b/lib/tasks/grant_contracts.rake
@@ -1,5 +1,5 @@
 namespace :grant_contracts do
-  desc %q{Create 'golden' files for comparison}
+  desc "Create 'golden' files for comparison"
   task create_golden: :environment do
     pdf_fixtures_path = File.join(Rails.root, 'spec', 'fixtures', 'pdfs')
 
@@ -11,10 +11,10 @@ namespace :grant_contracts do
 
       pdf = GrantContract.new(
         grant_name,
-        "SubmissionName",
-        "ArtistName",
-        "RequestedFundingDollars",
-        Time.parse("2017-01-07 20:17:40")
+        'SubmissionName',
+        'ArtistName',
+        'RequestedFundingDollars',
+        Time.parse('2017-01-07 20:17:40')
       )
 
       # create golden_file from generated
@@ -25,4 +25,3 @@ namespace :grant_contracts do
     end
   end
 end
-

--- a/lib/user_finder.rb
+++ b/lib/user_finder.rb
@@ -8,24 +8,18 @@ class UserFinder
       Voter.find_by(email: email)
     elsif type == 'admins'
       Admin.find_by(email: email)
-    else
-      nil
     end
   end
 
   def self.find_by_email!(type, email)
     user = find_by_email(type, email)
 
-    if user.nil?
-      raise ActiveRecord::RecordNotFound
-    end
+    raise ActiveRecord::RecordNotFound if user.nil?
 
     user
   end
 
-  private
-
-  def self.normalize_email(email)
+  private_class_method def self.normalize_email(email)
     URI.unescape(email).downcase
   end
 end

--- a/spec/controllers/account_activations_controller_spec.rb
+++ b/spec/controllers/account_activations_controller_spec.rb
@@ -5,7 +5,7 @@ describe AccountActivationsController do
 
       context 'with correct token' do
         it 'activates user' do
-          put 'edit', { type: 'artists', id: artist.activation_token, email: artist.email }
+          put 'edit', type: 'artists', id: artist.activation_token, email: artist.email
           expect(artist.reload).to be_activated
           expect(response).to render_template('success')
         end
@@ -13,7 +13,7 @@ describe AccountActivationsController do
 
       context 'with incorrect token' do
         it 'shows failure' do
-          put 'edit', { type: 'artists', id: 'incorrect_token', email: artist.email }
+          put 'edit', type: 'artists', id: 'incorrect_token', email: artist.email
           expect(artist.reload).not_to be_activated
           expect(response).to render_template('failure')
         end
@@ -25,7 +25,7 @@ describe AccountActivationsController do
 
       context 'with correct token' do
         it 'shows success' do
-          put 'edit', { type: 'artists', id: artist.activation_token, email: artist.email }
+          put 'edit', type: 'artists', id: artist.activation_token, email: artist.email
           expect(response).to render_template('success')
         end
       end
@@ -36,14 +36,14 @@ describe AccountActivationsController do
 
       context 'with incorrect email' do
         it 'shows failure' do
-          put 'edit', { type: 'artists', id: artist.activation_token, email: 'test@example.com' }
+          put 'edit', type: 'artists', id: artist.activation_token, email: 'test@example.com'
           expect(response).to render_template('failure')
         end
       end
     end
   end
 
-  describe "#unactivated" do
+  describe '#unactivated' do
     it 'returns ok' do
       get 'unactivated'
       expect(response).to be_ok

--- a/spec/controllers/grant_submissions_controller_spec.rb
+++ b/spec/controllers/grant_submissions_controller_spec.rb
@@ -1,5 +1,5 @@
 describe GrantSubmissionsController do
-  let!(:grant) { FactoryGirl.create(:grant)}
+  let!(:grant) { FactoryGirl.create(:grant) }
   let!(:artist) { FactoryGirl.create(:artist) }
   let!(:grant_submission) { FactoryGirl.create(:grant_submission, artist: artist, grant: grant) }
 
@@ -11,7 +11,7 @@ describe GrantSubmissionsController do
         render_views
 
         it 'shows discussion page' do
-          get 'discuss', { id: grant_submission.id }
+          get 'discuss', id: grant_submission.id
           expect(response).to render_template('grant_submissions/discuss')
 
           # this is an artist, so we can edit the answers but not questions
@@ -20,7 +20,7 @@ describe GrantSubmissionsController do
           # There has got to be an easier way to test for nonexistence of an attr.
           assert_select 'textarea#grant_submission_answers' do |e|
             e.each do |t|
-              assert !t.attributes.has_key?('disabled')
+              expect(t.attributes).not_to have_key('disabled')
             end
           end
         end
@@ -28,7 +28,7 @@ describe GrantSubmissionsController do
 
       context 'with non-existent grant_submission id' do
         it 'redirects to /' do
-          get 'discuss', { id: GrantSubmission.count + 1 }
+          get 'discuss', id: GrantSubmission.count + 1
           expect(response).to redirect_to('/')
         end
       end
@@ -37,7 +37,7 @@ describe GrantSubmissionsController do
         let!(:another_grant_submission) { FactoryGirl.create(:grant_submission) }
 
         it 'redirects to /' do
-          get 'discuss', { id: another_grant_submission.id }
+          get 'discuss', id: another_grant_submission.id
           expect(response).to redirect_to('/')
         end
       end
@@ -52,7 +52,7 @@ describe GrantSubmissionsController do
         render_views
 
         it 'shows discussion page' do
-          get 'discuss', { id: grant_submission.id }
+          get 'discuss', id: grant_submission.id
           expect(response).to render_template('grant_submissions/discuss')
 
           # this is a voter, can't edit either
@@ -63,7 +63,7 @@ describe GrantSubmissionsController do
 
       context 'with non-existent grant_submission id' do
         it 'redirects to /' do
-          get 'discuss', { id: GrantSubmission.count + 1 }
+          get 'discuss', id: GrantSubmission.count + 1
           expect(response).to redirect_to('/')
         end
       end
@@ -78,18 +78,18 @@ describe GrantSubmissionsController do
         render_views
 
         it 'shows discussion page' do
-          get 'discuss', { id: grant_submission.id }
+          get 'discuss', id: grant_submission.id
           expect(response).to render_template('grant_submissions/discuss')
 
           # this is an admin, can edit both
           assert_select 'textarea#grant_submission_questions' do |e|
             e.each do |t|
-              assert !t.attributes.has_key?('disabled')
+              expect(t.attributes).not_to have_key('disabled')
             end
           end
           assert_select 'textarea#grant_submission_answers' do |e|
             e.each do |t|
-              assert !t.attributes.has_key?('disabled')
+              expect(t.attributes).not_to have_key('disabled')
             end
           end
         end
@@ -97,7 +97,7 @@ describe GrantSubmissionsController do
 
       context 'with non-existent grant_submission id' do
         it 'redirects to /' do
-          get 'discuss', { id: GrantSubmission.count + 1 }
+          get 'discuss', id: GrantSubmission.count + 1
           expect(response).to redirect_to('/')
         end
       end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -9,7 +9,7 @@ describe PasswordResetsController do
 
   describe '#new' do
     it 'renders expected template' do
-      get 'new', { type: 'artists' }
+      get 'new', type: 'artists'
       expect(response).to render_template('password_resets/new')
     end
   end
@@ -17,7 +17,7 @@ describe PasswordResetsController do
   describe '#create' do
     context 'with missing email' do
       it 'shows a flash' do
-        post 'create', { password_reset: { email: '', type: 'artists' } }
+        post 'create', password_reset: { email: '', type: 'artists' }
         expect(flash).not_to be_empty
         expect(response).to render_template('password_resets/failure')
       end
@@ -48,21 +48,21 @@ describe PasswordResetsController do
     render_views
 
     it 'shows password edit' do
-      get 'edit', { id: artist.reset_token, email: artist.email, type: 'artists' }
+      get 'edit', id: artist.reset_token, email: artist.email, type: 'artists'
       expect(response).to render_template('password_resets/edit')
-      assert_select "input[name=email][type=hidden][value=?]", artist.email
+      assert_select 'input[name=email][type=hidden][value=?]', artist.email
     end
 
     context 'with incorrect reset_token' do
       it 'shows failure' do
-        get 'edit', { id: 'wrong token', email: artist.email, type: 'artists' }
+        get 'edit', id: 'wrong token', email: artist.email, type: 'artists'
         expect(response).to render_template('password_resets/failure')
       end
     end
 
     context 'with inactive artist' do
       it 'does not allow editing' do
-        get 'edit', { id: inactive_artist.reset_token, email: inactive_artist.email, type: 'artists' }
+        get 'edit', id: inactive_artist.reset_token, email: inactive_artist.email, type: 'artists'
         expect(response).to render_template('password_resets/failure')
       end
     end
@@ -70,12 +70,14 @@ describe PasswordResetsController do
 
   describe '#update' do
     def go!
-      patch 'update', { id: artist.reset_token, email: artist.email, type: 'artists',
-        artist: {
-          password: password,
-          password_confirmation: password_confirmation
-        }
-      }
+      patch 'update',
+            id: artist.reset_token,
+            email: artist.email,
+            type: 'artists',
+            artist: {
+              password: password,
+              password_confirmation: password_confirmation
+            }
     end
 
     context 'with matching password and password_confirmation' do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -3,7 +3,7 @@ describe SessionsController do
     let!(:artist) { FactoryGirl.create(:artist, :activated) }
 
     it 'allows logging in with case-insensitive email' do
-      post 'create_artist', { session: { email: artist.email.upcase, password: artist.password } }
+      post 'create_artist', session: { email: artist.email.upcase, password: artist.password }
       expect(response).to redirect_to('/artists')
     end
 
@@ -11,7 +11,7 @@ describe SessionsController do
       let!(:inactive_artist) { FactoryGirl.create(:artist) }
 
       it 'redirects to account activation' do
-        post 'create_artist', { session: { email: inactive_artist.email, password: inactive_artist.password } }
+        post 'create_artist', session: { email: inactive_artist.email, password: inactive_artist.password }
         expect(response).to redirect_to(account_activations_unactivated_path(email: inactive_artist.email, type: 'artists'))
       end
     end
@@ -21,7 +21,7 @@ describe SessionsController do
     let!(:voter) { FactoryGirl.create(:voter, :activated) }
 
     it 'allows logging in with case-insensitive email' do
-      post 'create_voter', { session: { email: voter.email.upcase, password: voter.password } }
+      post 'create_voter', session: { email: voter.email.upcase, password: voter.password }
       expect(response).to redirect_to('/voters')
     end
 
@@ -29,7 +29,7 @@ describe SessionsController do
       let!(:inactive_voter) { FactoryGirl.create(:voter) }
 
       it 'redirects to account activation' do
-        post 'create_voter', { session: { email: inactive_voter.email, password: inactive_voter.password } }
+        post 'create_voter', session: { email: inactive_voter.email, password: inactive_voter.password }
         expect(response).to redirect_to(account_activations_unactivated_path(email: inactive_voter.email, type: 'voters'))
       end
     end
@@ -39,7 +39,7 @@ describe SessionsController do
     let!(:admin) { FactoryGirl.create(:admin, :activated) }
 
     it 'allows logging in with case-insensitive email' do
-      post 'create_admin', { session: { email: admin.email.upcase, password: admin.password } }
+      post 'create_admin', session: { email: admin.email.upcase, password: admin.password }
       expect(response).to redirect_to('/admins')
     end
 
@@ -47,7 +47,7 @@ describe SessionsController do
       let!(:inactive_admin) { FactoryGirl.create(:admin) }
 
       it 'redirects to account activation' do
-        post 'create_admin', { session: { email: inactive_admin.email, password: inactive_admin.password } }
+        post 'create_admin', session: { email: inactive_admin.email, password: inactive_admin.password }
         expect(response).to redirect_to(account_activations_unactivated_path(email: inactive_admin.email, type: 'admins'))
       end
     end

--- a/spec/controllers/voters_controller_spec.rb
+++ b/spec/controllers/voters_controller_spec.rb
@@ -1,12 +1,12 @@
 describe VotersController do
-  describe "#signup" do
+  describe '#signup' do
     it 'returns ok' do
       get 'signup'
       expect(response).to be_ok
     end
   end
 
-  describe "#create" do
+  describe '#create' do
     let(:voter_params) { FactoryGirl.attributes_for(:voter) }
     let(:voter_survey_params) { FactoryGirl.attributes_for(:voter_survey) }
     let(:grants_voter) { FactoryGirl.attributes_for(:grants_voter) }
@@ -14,7 +14,7 @@ describe VotersController do
       {
         voter: voter_params,
         survey: voter_survey_params,
-        grants_voters: [grants_voter],
+        grants_voters: [grants_voter]
       }
     end
 
@@ -35,7 +35,7 @@ describe VotersController do
       let!(:existing_voter) { FactoryGirl.create(:voter, :activated) }
 
       it 'returns an error' do
-        post 'create', { voter: { email: existing_voter.email } }
+        post 'create', voter: { email: existing_voter.email }
         expect(response).to render_template('signup_failure')
       end
     end
@@ -44,7 +44,7 @@ describe VotersController do
   describe '#index' do
     it 'shows index template' do
       get 'index'
-      assert_template "index"
+      assert_template 'index'
     end
 
     context 'with activated voter' do
@@ -56,7 +56,7 @@ describe VotersController do
 
       it 'shows index template' do
         get 'index'
-        assert_template "index"
+        assert_template 'index'
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,4 +7,3 @@ FactoryGirl.define do
     Faker::Number.between(0, 2)
   end
 end
-

--- a/spec/factories/admin.rb
+++ b/spec/factories/admin.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :admin do
-    name { Faker::Name::name }
+    name { Faker::Name.name }
     email
     password { Faker::Internet.password }
 

--- a/spec/factories/voter.rb
+++ b/spec/factories/voter.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :voter do
-    name { Faker::Name::name }
+    name { Faker::Name.name }
     email
     password { Faker::Internet.password }
 

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,12 +1,11 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
-
   def account_activation
     if artist.activation_token.nil?
       artist.activation_token = ApplicationController.new_token
     end
 
-    UserMailer.account_activation("artists", artist)
+    UserMailer.account_activation('artists', artist)
   end
 
   def password_reset
@@ -14,23 +13,23 @@ class UserMailerPreview < ActionMailer::Preview
       artist.reset_token = ApplicationController.new_token
     end
 
-    UserMailer.password_reset("artists", artist)
+    UserMailer.password_reset('artists', artist)
   end
 
   def voter_verified
-    UserMailer.voter_verified(voter, "2017")
+    UserMailer.voter_verified(voter, '2017')
   end
 
   def grant_funded
-    UserMailer.grant_funded(grant_submission, artist, grant, "2017")
+    UserMailer.grant_funded(grant_submission, artist, grant, '2017')
   end
 
   def grant_not_funded
-    UserMailer.grant_not_funded(grant_submission, artist, grant, "2017")
+    UserMailer.grant_not_funded(grant_submission, artist, grant, '2017')
   end
 
   def notify_questions
-    UserMailer.notify_questions(grant_submission, artist, grant, "2017")
+    UserMailer.notify_questions(grant_submission, artist, grant, '2017')
   end
 
   private
@@ -50,5 +49,4 @@ class UserMailerPreview < ActionMailer::Preview
   def grant
     @grant ||= Grant.first || FactoryGirl.create(:grant)
   end
-
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -43,13 +43,13 @@ describe UserMailer do
 
     subject { UserMailer.grant_funded(grant_submission, artist, grant, '2020') }
 
-    its(:subject) { is_expected.to eq("2020 Firefly Creativity Grant Decision: #{ grant_submission.name }") }
+    its(:subject) { is_expected.to eq("2020 Firefly Creativity Grant Decision: #{grant_submission.name}") }
     its(:from) { is_expected.to include('grants@fireflyartscollective.org') }
     its(:to) { is_expected.to eq([artist.email]) }
 
     it do
       expect(subject.body.encoded).to include('Congratulations')
-      expect(subject.body.encoded).to include("$800")
+      expect(subject.body.encoded).to include('$800')
     end
   end
 
@@ -59,7 +59,7 @@ describe UserMailer do
 
     subject { UserMailer.grant_not_funded(grant_submission, artist, grant, '2020') }
 
-    its(:subject) { is_expected.to eq("2020 Firefly Creativity Grant Decision: #{ grant_submission.name }") }
+    its(:subject) { is_expected.to eq("2020 Firefly Creativity Grant Decision: #{grant_submission.name}") }
     its(:from) { is_expected.to include('grants@fireflyartscollective.org') }
     its(:to) { is_expected.to eq([artist.email]) }
 

--- a/spec/pdf/grant_contract_spec.rb
+++ b/spec/pdf/grant_contract_spec.rb
@@ -8,14 +8,14 @@ describe GrantContract do
     it do
       pdf_fixtures_path = File.join(Rails.root, 'spec', 'fixtures', 'pdfs')
       golden_file = File.join(pdf_fixtures_path, "#{grant_name}.txt")
-      golden_text = File.open(golden_file, "rb").read.strip
+      golden_text = File.open(golden_file, 'rb').read.strip
 
       pdf = GrantContract.new(
         grant_name,
-        "SubmissionName",
-        "ArtistName",
-        "RequestedFundingDollars",
-        Time.parse("2017-01-07 20:17:40")
+        'SubmissionName',
+        'ArtistName',
+        'RequestedFundingDollars',
+        Time.parse('2017-01-07 20:17:40')
       )
 
       pdf_text = PDF::Inspector::Text.analyze(pdf.render).strings.join("\n").strip

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:


### PR DESCRIPTION
Adds Rubocop gem with some minor tweaks: https://github.com/ywwg/ffagc/compare/master...FireflyArtsCollective:rubocop?expand=1#diff-11a0d7906801d9dea0eccb85667ad811

Fixes all issues reported by Rubocop in `specs/` and `app/models` since that code was already close to passing. I will run Rubocop on files as I edit them but it currently reports over 800 issues for the project.

To run Rubocop on the project make sure the gem is installed (it is now included in the Gemfile so `bundle install` will take care of that) and run `bundle exec rubocop`.

DOES NOT edit circle.yml to run rubocop, however that is probably worth doing when this repo is opted in to [CircleCI](https://circleci.com/).